### PR TITLE
Pin toolchain to absolute path to not confuse bazel

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,10 +25,19 @@ else
     BUILD_FLAGS="--cpu=arm64-v8a"
 fi
 
+# SW-21674: The path cannot be a symlink or else bazel will complain because
+# this path is added to cxx_builtin_include_directories as-is, but bazel
+# resolves the full paths to detected dependencies and does string comparisons,
+# not same-file comparisons.
+if [ "$SDK_PATH" != $(realpath "$SDK_PATH") ] ; then
+    echo "$SDK_PATH -> $(realpath "$SDK_PATH") cannot be a symlink! See SW-21674."
+    exit 1
+fi
+
 # Configure the build.
 PATH=$SDK_PATH/usr/bin:$PATH \
 PYTHON_BIN_PATH=$SDK_PATH/usr/bin/python3 \
-PYTHON_LIB_PATH=$SDK_PATH/usr/lib/python3.7/site-packages \
+PYTHON_LIB_PATH=$($SDK_PATH/usr/bin/python3 -c "import sysconfig; print(sysconfig.get_paths()['purelib'])") \
 TF_ENABLE_XLA=1 \
 TF_NEED_OPENCL_SYCL=0 \
 TF_NEED_ROCM=0 \

--- a/third_party/toolchains/cerebras/toolchain.bzl
+++ b/third_party/toolchains/cerebras/toolchain.bzl
@@ -5,9 +5,9 @@
 
 # Path to the Buildroot SDKs.
 # XXX (markh): Pin the toolchain to a specific version once stable.
-X86_64_SDK_PATH="/cb/toolchains/buildroot/monolith-default/latest/sdk-default-x86_64"
+X86_64_SDK_PATH="/cb/toolchains/buildroot/monolith-default/202005042248-19-de8df9c4/sdk-default-x86_64"
 # XXX (markh): Maybe eventually.
-AARCH64_SDK_PATH="/cb/toolchains/buildroot/monolith-default/latest/sdk-default-aarch64"
+AARCH64_SDK_PATH="/cb/toolchains/buildroot/monolith-default/202005042248-19-de8df9c4/sdk-default-aarch64"
 
 # The gcc version string is used to specify the paths to gcc include directories
 # (see cc_toolchain_config.bzl).


### PR DESCRIPTION
1. And also to keep ourselves honest about which tensorflow we used to build
tensorflow.

2. Add guard against accidentally specifying a symlink in the future.

3. Derive PYTHON_LIB_PATH.

Jira issue: SW-21674
testing: csub -j4 ./build.sh. Was able to reproduce the original problem. Went
away with this change (even without the release script workaround).